### PR TITLE
'faker-factory' is deprecated and crashes telling to use 'Faker'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     install_requires=[
         'morepath>=0.14',
         'more.jinja2',
-        'fake-factory',
+        'Faker',
     ],
     extras_require=dict(
         test=[


### PR DESCRIPTION
Hi there,

I tried to use this example, but it wouldn't work because of the obsolete dependency `fake-factory`. My fix was to replace it with `Faker` and everything is fine now.